### PR TITLE
Chore: add Chinese and Japanese support to NormcoreGM.cs and langselectbtn.cs

### DIFF
--- a/Assets/Scripts/NormcoreGM.cs
+++ b/Assets/Scripts/NormcoreGM.cs
@@ -158,6 +158,11 @@ public class NormcoreGM : MonoBehaviour
 
         _chatSync.SendMessage(newMessage);
     }
+    
+    public void SetLang(string language){
+        Debug.Log($"Language set to {language}");
+        this.profile.Language = languagePairs[language.ToLower()];
+    }
 
     //Sets the profile language to english
     public void SetLangEnglish() {
@@ -178,7 +183,8 @@ public class NormcoreGM : MonoBehaviour
         string lang = inputField_ln.options[inputField_ln.value].text;
         this.profile.Language = inputField_ln.options[inputField_ln.value].text;
         Debug.Log("Language Inputed: " + profile.Language);
-        this.profile.Language = languagePairs[lang.ToLower()];
+        SetLang(profile.Language);
+        // this.profile.Language = languagePairs[lang.ToLower()];
         /*if (lang == "English"){
             SetLangEnglish();
         }

--- a/Assets/Scripts/NormcoreGM.cs
+++ b/Assets/Scripts/NormcoreGM.cs
@@ -37,8 +37,8 @@ public class NormcoreGM : MonoBehaviour
         {
             { "english", "en" },
             { "spanish", "es" },
-            { "chinese", "zh" },
-            { "japanese", "ja" }
+            { "中文", "zh" },
+            { "日本語", "ja" }
         };
         _sampleRate = AudioSettings.outputSampleRate;
         monitoringClip = Microphone.Start(null, true, 10, _sampleRate);

--- a/Assets/Scripts/NormcoreGM.cs
+++ b/Assets/Scripts/NormcoreGM.cs
@@ -27,11 +27,19 @@ public class NormcoreGM : MonoBehaviour
     private AudioClip monitoringClip; 
     private float timeSinceLastSpeech = 0f;
     private const float speechCooldown = 3f;
+    private Dictionary<string, string> languagePairs;
 
     void Start()
     {
         this.profile = new ProfileClass();
         this.profile.Messages = new List<Message>();
+        this.languagePairs = new Dictionary<string, string>
+        {
+            { "english", "en" },
+            { "spanish", "es" },
+            { "chinese", "zh" },
+            { "japanese", "ja" }
+        };
         _sampleRate = AudioSettings.outputSampleRate;
         monitoringClip = Microphone.Start(null, true, 10, _sampleRate);
         while (!(Microphone.GetPosition(null) > 0)) {} 
@@ -168,14 +176,15 @@ public class NormcoreGM : MonoBehaviour
     public void GetInputLanguage()
     {
         string lang = inputField_ln.options[inputField_ln.value].text;
-        profile.Language = inputField_ln.options[inputField_ln.value].text;
+        this.profile.Language = inputField_ln.options[inputField_ln.value].text;
         Debug.Log("Language Inputed: " + profile.Language);
-        if (lang == "English"){
+        this.profile.Language = languagePairs[lang.ToLower()];
+        /*if (lang == "English"){
             SetLangEnglish();
         }
         else if (lang == "Spanish"){
             SetLangSpanish();
-        }
+        }*/
     }
 
     //Gets the inputed username

--- a/Assets/Scripts/langselectbtn.cs
+++ b/Assets/Scripts/langselectbtn.cs
@@ -27,12 +27,17 @@ public class langselectbtn : MonoBehaviour
             Debug.Log("enter a name");
             return;
         }
+        else if(lang != ""){
+            normcoreGM.SetLang(lang);
+        }
+        /*
         else if(lang=="English"){
             normcoreGM.SetLangEnglish();
         }
         else if(lang=="Spanish"){
             normcoreGM.SetLangSpanish();
         }
+        */
         else{
             Debug.Log("no language");
         }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -10,6 +10,7 @@
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.6",
+    "com.unity.toolchain.linux-x86_64": "2.0.6",
     "com.unity.ugui": "1.0.0",
     "com.unity.visualscripting": "1.9.1",
     "com.unity.xr.interaction.toolkit": "2.5.3",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -287,6 +287,22 @@
         "com.unity.searcher": "4.9.2"
       }
     },
+    "com.unity.sysroot": {
+      "version": "2.0.7",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.sysroot.linux-x86_64": {
+      "version": "2.0.6",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.7"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.test-framework": {
       "version": "1.1.33",
       "depth": 0,
@@ -316,6 +332,16 @@
         "com.unity.modules.animation": "1.0.0",
         "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.toolchain.linux-x86_64": {
+      "version": "2.0.6",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.7",
+        "com.unity.sysroot.linux-x86_64": "2.0.6"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
Do actually review the changes in these files, as they are **untested** and effectively deprecate the discrete `SetLang` functions (i.e., `SetLang(string lang)` replaces `SetLangChinese()`, etc.).